### PR TITLE
Restore analyser retry workflow

### DIFF
--- a/analyser/processQueue.sh
+++ b/analyser/processQueue.sh
@@ -395,13 +395,19 @@ show_log_tail()
 report_analysis_failure()
 {
 	appId="$1"
-	curl -sS --fail -K "$curl_auth_config" "$SERVER/reportAnalysisFailure?appId=$appId&analysisVersion=$ANALYSIS_VERSION" --data-binary "@$log" -H "Content-Type: text/plain" > /dev/null
+	curl -sS --fail -K "$curl_auth_config" "$SERVER/reportAnalysisFailure" \
+		--url-query "appId=$appId" \
+		--url-query "analysisVersion=$ANALYSIS_VERSION" \
+		--data-binary "@$log" -H "Content-Type: text/plain" > /dev/null
 }
 
 upload_analysis()
 {
 	appId="$1"
-	curl -sS --fail -K "$curl_auth_config" "$SERVER/uploadAnalysis?appId=$appId&analysisVersion=$ANALYSIS_VERSION" -d @"analysis/$appId.json" -H "Content-Type: application/json" > /dev/null
+	curl -sS --fail -K "$curl_auth_config" "$SERVER/uploadAnalysis" \
+		--url-query "appId=$appId" \
+		--url-query "analysisVersion=$ANALYSIS_VERSION" \
+		-d @"analysis/$appId.json" -H "Content-Type: application/json" > /dev/null
 }
 
 download()

--- a/analyser/processQueue.sh
+++ b/analyser/processQueue.sh
@@ -392,21 +392,33 @@ show_log_tail()
 	fi
 }
 
+# percent-encode a query-string value (curl's --url-query needs >= 7.87)
+urlencode()
+{
+	local LC_ALL=C string="$1" out="" c i
+	for ((i = 0; i < ${#string}; i++)); do
+		c="${string:i:1}"
+		case "$c" in
+			[A-Za-z0-9.~_-]) out+="$c" ;;
+			*) printf -v c '%%%02X' "'$c"; out+="$c" ;;
+		esac
+	done
+	printf '%s' "$out"
+}
+
 report_analysis_failure()
 {
 	appId="$1"
-	curl -sS --fail -K "$curl_auth_config" "$SERVER/reportAnalysisFailure" \
-		--url-query "appId=$appId" \
-		--url-query "analysisVersion=$ANALYSIS_VERSION" \
+	curl -sS --fail -K "$curl_auth_config" \
+		"$SERVER/reportAnalysisFailure?appId=$(urlencode "$appId")&analysisVersion=$(urlencode "$ANALYSIS_VERSION")" \
 		--data-binary "@$log" -H "Content-Type: text/plain" > /dev/null
 }
 
 upload_analysis()
 {
 	appId="$1"
-	curl -sS --fail -K "$curl_auth_config" "$SERVER/uploadAnalysis" \
-		--url-query "appId=$appId" \
-		--url-query "analysisVersion=$ANALYSIS_VERSION" \
+	curl -sS --fail -K "$curl_auth_config" \
+		"$SERVER/uploadAnalysis?appId=$(urlencode "$appId")&analysisVersion=$(urlencode "$ANALYSIS_VERSION")" \
 		-d @"analysis/$appId.json" -H "Content-Type: application/json" > /dev/null
 }
 

--- a/lib/analysisFailure.js
+++ b/lib/analysisFailure.js
@@ -1,0 +1,38 @@
+function classifyAnalysisFailure(logs) {
+  const text = logs || '';
+
+  if (/app not found/i.test(text)) {
+    return {
+      reason: 'app_not_found',
+      retryable: false
+    };
+  }
+
+  if (/Download exceeded MAX_ATTEMPT_DOWNLOAD_BYTES|above MAX_APP_SIZE_BYTES/i.test(text)) {
+    return {
+      reason: 'ipa_too_large',
+      retryable: false
+    };
+  }
+
+  if (/DeviceOSVersionTooLow|system version is lower than the minimum OS version/i.test(text)) {
+    return {
+      reason: 'ios_version_too_low',
+      retryable: false
+    };
+  }
+
+  if (/purchasing paid apps is not supported/i.test(text)) {
+    return {
+      reason: 'paid_app',
+      retryable: false
+    };
+  }
+
+  return {
+    reason: 'analysis_failed',
+    retryable: true
+  };
+}
+
+module.exports = { classifyAnalysisFailure };

--- a/lib/appId.js
+++ b/lib/appId.js
@@ -10,8 +10,17 @@ function isValidAppId(value) {
     && !value.endsWith('.');
 }
 
+// Bundle IDs are case-insensitive on the App Store; lookups may return the
+// canonical casing rather than the one requested.
+function isSameAppId(a, b) {
+  return typeof a === 'string'
+    && typeof b === 'string'
+    && a.toLowerCase() === b.toLowerCase();
+}
+
 module.exports = {
   APP_ID_PATTERN_SOURCE,
   MAX_APP_ID_LENGTH,
+  isSameAppId,
   isValidAppId
 };

--- a/lib/appId.js
+++ b/lib/appId.js
@@ -1,0 +1,17 @@
+const MAX_APP_ID_LENGTH = 255;
+const APP_ID_PATTERN_SOURCE = '^[A-Za-z0-9][A-Za-z0-9.-]*$';
+const APP_ID_PATTERN = new RegExp(APP_ID_PATTERN_SOURCE);
+
+function isValidAppId(value) {
+  return typeof value === 'string'
+    && value.length > 0
+    && value.length <= MAX_APP_ID_LENGTH
+    && APP_ID_PATTERN.test(value)
+    && !value.endsWith('.');
+}
+
+module.exports = {
+  APP_ID_PATTERN_SOURCE,
+  MAX_APP_ID_LENGTH,
+  isValidAppId
+};

--- a/lib/appStore.js
+++ b/lib/appStore.js
@@ -1,5 +1,5 @@
 const https = require('https');
-const { isValidAppId } = require('./appId');
+const { isSameAppId, isValidAppId } = require('./appId');
 
 function requestJson(url) {
   return new Promise((resolve, reject) => {
@@ -94,7 +94,7 @@ async function app({ appId, country }) {
   if (!result) throw new Error('App not found (404)');
 
   const normalized = normalize(result);
-  if (normalized.appId !== appId) throw new Error('App not found (404)');
+  if (!isSameAppId(normalized.appId, appId)) throw new Error('App not found (404)');
 
   return normalized;
 }

--- a/lib/appStore.js
+++ b/lib/appStore.js
@@ -1,4 +1,5 @@
 const https = require('https');
+const { isValidAppId } = require('./appId');
 
 function requestJson(url) {
   return new Promise((resolve, reject) => {
@@ -75,10 +76,14 @@ async function search({ term, num, country }) {
     limit: String(num || 5)
   });
   const data = await requestJson(`https://itunes.apple.com/search?${params.toString()}`);
-  return (data.results || []).map(normalize);
+  return (data.results || [])
+    .map(normalize)
+    .filter((result) => isValidAppId(result.appId));
 }
 
 async function app({ appId, country }) {
+  if (!isValidAppId(appId)) throw new Error('Invalid App Store bundle ID');
+
   const params = new URLSearchParams({
     bundleId: appId,
     country,
@@ -88,7 +93,10 @@ async function app({ appId, country }) {
   const result = data.results && data.results[0];
   if (!result) throw new Error('App not found (404)');
 
-  return normalize(result);
+  const normalized = normalize(result);
+  if (normalized.appId !== appId) throw new Error('App not found (404)');
+
+  return normalized;
 }
 
 module.exports = { search, app };

--- a/migrations/003_reject_invalid_app_ids.sql
+++ b/migrations/003_reject_invalid_app_ids.sql
@@ -1,0 +1,20 @@
+UPDATE apps
+SET analysis = (
+    COALESCE(analysis::jsonb, '{}'::jsonb) || jsonb_build_object(
+        'success', false,
+        'reason', 'invalid_bundle_id',
+        'retryable', false,
+        'logs', 'Invalid App Store bundle ID quarantined by migration 003.'
+    )
+)::json
+WHERE length(appid) > 255
+   OR appid !~ '^[A-Za-z0-9][A-Za-z0-9.-]*$'
+   OR appid ~ '[.]$';
+
+ALTER TABLE apps
+ADD CONSTRAINT apps_appid_valid
+CHECK (
+    length(appid) BETWEEN 1 AND 255
+    AND appid ~ '^[A-Za-z0-9][A-Za-z0-9.-]*$'
+    AND appid !~ '[.]$'
+) NOT VALID;

--- a/migrations/004_mark_ios_version_too_low_non_retryable.sql
+++ b/migrations/004_mark_ios_version_too_low_non_retryable.sql
@@ -1,0 +1,10 @@
+UPDATE apps
+SET analysis = (
+    analysis::jsonb || '{"reason":"ios_version_too_low","retryable":false}'::jsonb
+)::json
+WHERE analysis IS NOT NULL
+  AND analysis->>'success' = 'false'
+  AND (
+      analysis->>'logs' ILIKE '%DeviceOSVersionTooLow%'
+      OR analysis->>'logs' ILIKE '%system version is lower than the minimum OS version%'
+  );

--- a/migrations/005_mark_paid_apps_non_retryable.sql
+++ b/migrations/005_mark_paid_apps_non_retryable.sql
@@ -1,0 +1,7 @@
+UPDATE apps
+SET analysis = (
+    analysis::jsonb || '{"reason":"paid_app","retryable":false}'::jsonb
+)::json
+WHERE analysis IS NOT NULL
+  AND analysis->>'success' = 'false'
+  AND analysis->>'logs' ILIKE '%purchasing paid apps is not supported%';

--- a/models/Apps.js
+++ b/models/Apps.js
@@ -1,4 +1,9 @@
 const { Pool } = require('pg');
+const {
+    APP_ID_PATTERN_SOURCE,
+    MAX_APP_ID_LENGTH,
+    isValidAppId
+} = require('../lib/appId');
 const pool = new Pool(
     process.env.DATABASE_URL
         ? { connectionString: process.env.DATABASE_URL }
@@ -19,6 +24,8 @@ const healthCheck = async () => {
 }
 
 const findApp = async (appId) => {
+    if (!isValidAppId(appId)) return null;
+
     const result = await pool.query('SELECT * FROM apps WHERE appid = $1', [appId]);
     if (result.rows.length == 0)
         return null;
@@ -28,15 +35,33 @@ const findApp = async (appId) => {
 
 const countQueue = async (added) => {
     if (added) {
-        const result = await pool.query('SELECT COUNT(*) FROM apps WHERE analysis IS NULL AND added < $1', [added]);
+        const result = await pool.query(`
+            SELECT COUNT(*)
+            FROM apps
+            WHERE analysis IS NULL
+                AND added < $1
+                AND appid ~ $2
+                AND appid !~ '[.]$'
+                AND length(appid) <= $3
+        `, [added, APP_ID_PATTERN_SOURCE, MAX_APP_ID_LENGTH]);
         return result.rows[0].count;
     } else {
-        const result = await pool.query('SELECT COUNT(*) FROM apps WHERE analysis IS NULL');
+        const result = await pool.query(`
+            SELECT COUNT(*)
+            FROM apps
+            WHERE analysis IS NULL
+                AND appid ~ $1
+                AND appid !~ '[.]$'
+                AND length(appid) <= $2
+        `, [APP_ID_PATTERN_SOURCE, MAX_APP_ID_LENGTH]);
         return result.rows[0].count;
     }
 }
 
 const addApp = async (appId, details) => {
+    if (!isValidAppId(appId)) throw new TypeError('Invalid App Store bundle ID');
+    if (!details || details.appId !== appId) throw new TypeError('App Store bundle ID mismatch');
+
     const result = await pool.query('INSERT INTO apps (appid, details) VALUES ($1, $2)', [appId, details]);
     return result;
 }
@@ -47,7 +72,7 @@ const popularityExpression = `
         ELSE 0
     END`;
 
-const currentAnalysisVersion = parseInt(process.env.CURRENT_ANALYSIS_VERSION || process.env.ANALYSIS_VERSION || '3', 10);
+const currentAnalysisVersion = parseInt(process.env.CURRENT_ANALYSIS_VERSION || process.env.ANALYSIS_VERSION || '4', 10);
 const staleAnalysisDays = parseInt(process.env.STALE_ANALYSIS_DAYS || '180', 10);
 const processingTimeoutMinutes = parseInt(process.env.PROCESSING_TIMEOUT_MINUTES || '120', 10);
 
@@ -103,7 +128,10 @@ const nextApp = async () => {
         const candidate = await client.query(`
             SELECT appid, analysis
             FROM apps
-            WHERE COALESCE(analysis->>'retryable', 'true') <> 'false'
+            WHERE appid ~ $4
+                AND appid !~ '[.]$'
+                AND length(appid) <= $5
+                AND COALESCE(analysis->>'retryable', 'true') <> 'false'
                 AND (
                     analysis IS NULL
                     OR (
@@ -121,7 +149,13 @@ const nextApp = async () => {
             ORDER BY ${popularityExpression} DESC, added ASC
             LIMIT 1
             FOR UPDATE SKIP LOCKED
-        `, [currentAnalysisVersion, staleAnalysisDays, processingTimeoutMinutes]);
+        `, [
+            currentAnalysisVersion,
+            staleAnalysisDays,
+            processingTimeoutMinutes,
+            APP_ID_PATTERN_SOURCE,
+            MAX_APP_ID_LENGTH
+        ]);
 
         if (candidate.rowCount === 0) {
             await client.query('COMMIT');
@@ -153,6 +187,8 @@ const nextApp = async () => {
 };
 
 const updateAnalysis = async (appId, analysis, analysisVersion) => {
+    if (!isValidAppId(appId)) throw new TypeError('Invalid App Store bundle ID');
+
     const client = await pool.connect();
     try {
         await client.query('BEGIN');

--- a/package-lock.json
+++ b/package-lock.json
@@ -195,21 +195,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/body-parser/node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -493,14 +478,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -519,7 +504,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -1404,12 +1389,13 @@
       "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ=="
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1596,14 +1582,14 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1971,14 +1957,6 @@
             "toidentifier": "~1.0.1"
           }
         },
-        "qs": {
-          "version": "6.15.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-          "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-          "requires": {
-            "side-channel": "^1.1.0"
-          }
-        },
         "statuses": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2174,13 +2152,13 @@
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
     "express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -2199,7 +2177,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -2832,11 +2810,12 @@
       "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ=="
     },
     "qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "requires": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       }
     },
     "range-parser": {
@@ -2958,13 +2937,13 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "requires": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       }

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,6 +5,8 @@ const store = require('../lib/appStore');
 const Apps = require('../models/Apps');
 const jurisdiction = require('../lib/jurisdiction');
 const cache = require('../lib/cache');
+const { isValidAppId } = require('../lib/appId');
+const { classifyAnalysisFailure } = require('../lib/analysisFailure');
 
 // Taken from https://reports.exodus-privacy.eu.org/api/trackers
 const exodusTrackers = JSON.parse(fs.readFileSync('./exodusTrackers.json', 'utf-8'))
@@ -16,27 +18,6 @@ const router = express.Router();
 const COUNTRY = 'gb';
 
 let lastPing = 0; // unix timestamp
-
-function classifyAnalysisFailure(logs) {
-  if (/app not found/i.test(logs || '')) {
-    return {
-      reason: 'app_not_found',
-      retryable: false
-    };
-  }
-
-  if (/Download exceeded MAX_ATTEMPT_DOWNLOAD_BYTES|above MAX_APP_SIZE_BYTES/i.test(logs || '')) {
-    return {
-      reason: 'ipa_too_large',
-      retryable: false
-    };
-  }
-
-  return {
-    reason: 'analysis_failed',
-    retryable: true
-  };
-}
 
 // ping from analyser in past hour?
 router.use(function (req, res, next) {
@@ -274,8 +255,8 @@ router.post('/search',
 });
 
 router.get('/analysis/:appId', async (req, res) => {
-  if (!req.params.appId)
-    return res.status(400).send('Please provide app');
+  if (!isValidAppId(req.params.appId))
+    return res.status(400).send('Please provide a valid App Store bundle ID.');
   let appId = req.params.appId;
 
   console.log('Fetching', appId);
@@ -378,6 +359,9 @@ router.post('/uploadAnalysis', async (req, res) => {
   const appId = req.query.appId;
   const analysisVersion = req.query.analysisVersion;
 
+  if (!isValidAppId(appId))
+    return res.status(400).send('Please provide a valid App Store bundle ID.');
+
   console.log('Updating', appId);
 
   if (!req.body)
@@ -393,6 +377,9 @@ router.post('/uploadAnalysis', async (req, res) => {
 router.post('/reportAnalysisFailure', async (req, res) => {
   if (!req.query.appId || !req.query.analysisVersion)
     return res.status(400).send('Please provide appId and analysisVersion');
+
+  if (!isValidAppId(req.query.appId))
+    return res.status(400).send('Please provide a valid App Store bundle ID.');
 
   const logs = req.body; // should contain the log
   const failure = classifyAnalysisFailure(logs);

--- a/scripts/priority-report.js
+++ b/scripts/priority-report.js
@@ -9,7 +9,7 @@ dotenv.config({ path: path.join(__dirname, '..', 'analyser', '.env') });
 
 const limitArg = process.argv.find((arg) => arg.startsWith('--limit='));
 const limit = limitArg ? Math.max(1, parseInt(limitArg.split('=')[1], 10) || 20) : 20;
-const currentAnalysisVersion = parseInt(process.env.CURRENT_ANALYSIS_VERSION || process.env.ANALYSIS_VERSION || '3', 10);
+const currentAnalysisVersion = parseInt(process.env.CURRENT_ANALYSIS_VERSION || process.env.ANALYSIS_VERSION || '4', 10);
 const staleAnalysisDays = parseInt(process.env.STALE_ANALYSIS_DAYS || '180', 10);
 const processingTimeoutMinutes = parseInt(process.env.PROCESSING_TIMEOUT_MINUTES || '120', 10);
 

--- a/scripts/queue-refetch.js
+++ b/scripts/queue-refetch.js
@@ -10,6 +10,7 @@ dotenv.config({ path: path.join(__dirname, '..', 'analyser', '.env') });
 const args = new Set(process.argv.slice(2));
 const apply = args.has('--apply');
 const failed = args.has('--failed');
+const includeNonRetryable = args.has('--include-non-retryable');
 const appIds = process.argv
   .slice(2)
   .filter((arg) => arg.startsWith('--appid='))
@@ -100,7 +101,9 @@ async function main() {
     }
   } else {
     const where = failed
-      ? "analysis->>'success' = 'false' AND coalesce(analysis->>'logs', '') <> 'Processing in progress'"
+      ? `analysis->>'success' = 'false'
+          AND coalesce(analysis->>'logs', '') <> 'Processing in progress'
+          ${includeNonRetryable ? '' : "AND coalesce(analysis->>'retryable', 'true') <> 'false'"}`
       : "analysis IS NOT NULL AND coalesce(analysis->>'success', 'true') <> 'false'";
 
     const result = await client.query(`

--- a/scripts/queue-status.js
+++ b/scripts/queue-status.js
@@ -7,7 +7,7 @@ const { Client } = require('pg');
 dotenv.config({ path: path.join(__dirname, '..', '.env') });
 dotenv.config({ path: path.join(__dirname, '..', 'analyser', '.env') });
 
-const currentAnalysisVersion = parseInt(process.env.CURRENT_ANALYSIS_VERSION || process.env.ANALYSIS_VERSION || '3', 10);
+const currentAnalysisVersion = parseInt(process.env.CURRENT_ANALYSIS_VERSION || process.env.ANALYSIS_VERSION || '4', 10);
 const staleAnalysisDays = parseInt(process.env.STALE_ANALYSIS_DAYS || '180', 10);
 const processingTimeoutMinutes = parseInt(process.env.PROCESSING_TIMEOUT_MINUTES || '120', 10);
 
@@ -142,16 +142,19 @@ async function main() {
         ELSE 'stale by age'
       END AS reason
     FROM apps
-    WHERE analysis IS NULL
-      OR (
-        analysis->>'logs' = 'Processing in progress'
-        AND (analysis->>'timestamp')::timestamptz < NOW() - ($3::int * INTERVAL '1 minute')
-      )
-      OR (
-        coalesce(analysis->>'logs', '') <> 'Processing in progress'
-        AND (
-          analysisversion IS DISTINCT FROM $1
-          OR analysed < NOW() - ($2::int * INTERVAL '1 day')
+    WHERE coalesce(analysis->>'retryable', 'true') <> 'false'
+      AND (
+        analysis IS NULL
+        OR (
+          analysis->>'logs' = 'Processing in progress'
+          AND (analysis->>'timestamp')::timestamptz < NOW() - ($3::int * INTERVAL '1 minute')
+        )
+        OR (
+          coalesce(analysis->>'logs', '') <> 'Processing in progress'
+          AND (
+            analysisversion IS DISTINCT FROM $1
+            OR analysed < NOW() - ($2::int * INTERVAL '1 day')
+          )
         )
       )
     ORDER BY ${reviewsExpr} DESC, added ASC

--- a/test/analysisFailure.test.js
+++ b/test/analysisFailure.test.js
@@ -1,0 +1,24 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { classifyAnalysisFailure } = require('../lib/analysisFailure');
+
+test('marks minimum-iOS failures as non-retryable', () => {
+  assert.deepEqual(
+    classifyAnalysisFailure('Install failed: DeviceOSVersionTooLow. Have 16.7.11; need 17.0'),
+    { reason: 'ios_version_too_low', retryable: false }
+  );
+});
+
+test('keeps unknown analysis failures retryable', () => {
+  assert.deepEqual(
+    classifyAnalysisFailure('trackerscan exited unexpectedly'),
+    { reason: 'analysis_failed', retryable: true }
+  );
+});
+
+test('marks apps that became paid as non-retryable', () => {
+  assert.deepEqual(
+    classifyAnalysisFailure('ipatool: purchasing paid apps is not supported'),
+    { reason: 'paid_app', retryable: false }
+  );
+});

--- a/test/appId.test.js
+++ b/test/appId.test.js
@@ -1,0 +1,51 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { isValidAppId } = require('../lib/appId');
+const store = require('../lib/appStore');
+
+test('accepts App Store bundle identifiers used by the analyser', () => {
+  assert.equal(isValidAppId('app.organicmaps'), true);
+  assert.equal(isValidAppId('pl.nestbank.nestbank-prod'), true);
+  assert.equal(isValidAppId('com.substack.Substack'), true);
+});
+
+test('rejects malformed bundle identifiers observed in the production queue', () => {
+  assert.equal(isValidAppId('app.organicmaps&quot'), false);
+  assert.equal(isValidAppId('pl.nestbank.nestbank-prod&sa=U&ved=redirect'), false);
+  assert.equal(isValidAppId('com.substack.Substack&sa=U&ved=redirect'), false);
+  assert.equal(isValidAppId('.com.emf.detector.radiation.meter'), false);
+});
+
+test('rejects unsafe or structurally invalid bundle identifiers', () => {
+  assert.equal(isValidAppId(''), false);
+  assert.equal(isValidAppId('com.example.app.'), false);
+  assert.equal(isValidAppId('com/example/app'), false);
+  assert.equal(isValidAppId('com.example.app?source=search'), false);
+  assert.equal(isValidAppId(`com.example.${'a'.repeat(245)}`), false);
+});
+
+test('App Store lookup rejects malformed IDs before making a request', async () => {
+  await assert.rejects(
+    store.app({ appId: 'app.organicmaps&quot', country: 'gb' }),
+    /Invalid App Store bundle ID/
+  );
+});
+
+test('analysis route rejects malformed IDs before database lookup', async () => {
+  const app = require('../server');
+  const server = await new Promise((resolve) => {
+    const instance = app.listen(0, () => resolve(instance));
+  });
+
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${server.address().port}/analysis/app.organicmaps%26quot`
+    );
+    assert.equal(response.status, 400);
+    assert.match(await response.text(), /valid App Store bundle ID/);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((err) => err ? reject(err) : resolve());
+    });
+  }
+});

--- a/test/appId.test.js
+++ b/test/appId.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const { isValidAppId } = require('../lib/appId');
+const { isSameAppId, isValidAppId } = require('../lib/appId');
 const store = require('../lib/appStore');
 
 test('accepts App Store bundle identifiers used by the analyser', () => {
@@ -22,6 +22,13 @@ test('rejects unsafe or structurally invalid bundle identifiers', () => {
   assert.equal(isValidAppId('com/example/app'), false);
   assert.equal(isValidAppId('com.example.app?source=search'), false);
   assert.equal(isValidAppId(`com.example.${'a'.repeat(245)}`), false);
+});
+
+test('matches bundle identifiers case-insensitively, as the App Store does', () => {
+  assert.equal(isSameAppId('com.substack.substack', 'com.substack.Substack'), true);
+  assert.equal(isSameAppId('app.organicmaps', 'app.organicmaps'), true);
+  assert.equal(isSameAppId('app.organicmaps', 'app.organicmaps&quot'), false);
+  assert.equal(isSameAppId('app.organicmaps', undefined), false);
 });
 
 test('App Store lookup rejects malformed IDs before making a request', async () => {


### PR DESCRIPTION
## What changed

- validate App Store bundle IDs at lookup, queue, and analyser upload boundaries
- quarantine existing malformed IDs and prevent new invalid IDs at the database layer
- URL-encode analyser upload/failure query parameters
- retry only failures marked retryable by default
- classify minimum-iOS and paid-app failures as non-retryable
- align queue diagnostics with analysis version 4 and make backlog details match queue policy

## Why

The Raspberry Pi analyser was repeatedly receiving malformed bundle IDs containing redirect parameters and HTML fragments. Raw query-string interpolation could then report a malformed job against a valid bundle-ID prefix. The queue also treated permanent minimum-iOS and paid-app failures as retryable, while local diagnostics defaulted to version 3 and made the healthy version-4 dataset look entirely stale.

## Impact

Successful version-4 analyses remain untouched. Operators can restart only retryable failures, malformed IDs are excluded, permanent device/app incompatibilities stop cycling, and queue reports reflect the deployed policy.

## Validation

- `npm test` — 16 tests passed after rebasing onto current `main`
- production canary completed download, install, trackerscan, conversion, uninstall, and upload
- targeted five-app batch completed four successful analyses; the paid app was correctly identified as permanent
- final version-4 queue reported no active, expired, or pending work
