### PR TITLE
Fix database bugs: countAnalysed undercount, addApp race, app_analyses dedupe constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Website:
 - Node.js
 - npm
 - PostgreSQL
-- `DATABASE_URL` pointing at a database with the `apps` table
+- `DATABASE_URL` pointing at an empty PostgreSQL database (the schema is created by running `node scripts/migrate.js`)
 
 Analyser:
 

--- a/migrations/000_apps.sql
+++ b/migrations/000_apps.sql
@@ -1,0 +1,14 @@
+-- Baseline migration: create the apps table on fresh databases.
+-- IF NOT EXISTS makes this a no-op on existing databases where the table
+-- predates the migration system. Types deliberately match production
+-- (json, timestamp without time zone); the apps_appid_valid CHECK constraint
+-- is added later by migration 003.
+
+CREATE TABLE IF NOT EXISTS apps (
+    appid text PRIMARY KEY,
+    details json,
+    analysis json,
+    analysisversion integer,
+    analysed timestamp without time zone,
+    added timestamp without time zone NOT NULL DEFAULT NOW()
+);

--- a/migrations/006_app_analyses_unique.sql
+++ b/migrations/006_app_analyses_unique.sql
@@ -1,0 +1,13 @@
+-- Deduplicate app_analyses history rows and enforce a unique (appid, analysed)
+-- constraint so concurrent snapshot/history writers can rely on ON CONFLICT
+-- instead of a race-prone NOT EXISTS guard.
+
+-- Remove duplicate rows, keeping the lowest id per (appid, analysed) pair.
+DELETE FROM app_analyses a
+USING app_analyses b
+WHERE a.appid = b.appid
+  AND a.analysed = b.analysed
+  AND a.id > b.id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS app_analyses_appid_analysed_unique
+    ON app_analyses (appid, analysed);

--- a/models/Apps.js
+++ b/models/Apps.js
@@ -76,11 +76,6 @@ const currentAnalysisVersion = parseInt(process.env.CURRENT_ANALYSIS_VERSION || 
 const staleAnalysisDays = parseInt(process.env.STALE_ANALYSIS_DAYS || '180', 10);
 const processingTimeoutMinutes = parseInt(process.env.PROCESSING_TIMEOUT_MINUTES || '120', 10);
 
-async function historyTableExists(client) {
-    const result = await client.query("SELECT to_regclass('public.app_analyses') AS table_name");
-    return Boolean(result.rows[0].table_name);
-}
-
 async function snapshotCurrentAnalysis(client, appId) {
     await client.query(`
         INSERT INTO app_analyses (
@@ -164,7 +159,7 @@ const nextApp = async () => {
         }
 
         const app = candidate.rows[0];
-        if (app.analysis && app.analysis.logs !== 'Processing in progress' && await historyTableExists(client)) {
+        if (app.analysis && app.analysis.logs !== 'Processing in progress') {
             await snapshotCurrentAnalysis(client, app.appid);
         }
 
@@ -199,7 +194,7 @@ const updateAnalysis = async (appId, analysis, analysisVersion) => {
             [analysis, analysisVersion, appId]
         );
 
-        if (result.rowCount > 0 && await historyTableExists(client)) {
+        if (result.rowCount > 0) {
             const app = result.rows[0];
             await client.query(`
                 INSERT INTO app_analyses (

--- a/models/Apps.js
+++ b/models/Apps.js
@@ -62,7 +62,7 @@ const addApp = async (appId, details) => {
     if (!isValidAppId(appId)) throw new TypeError('Invalid App Store bundle ID');
     if (!details || details.appId !== appId) throw new TypeError('App Store bundle ID mismatch');
 
-    const result = await pool.query('INSERT INTO apps (appid, details) VALUES ($1, $2)', [appId, details]);
+    const result = await pool.query('INSERT INTO apps (appid, details) VALUES ($1, $2) ON CONFLICT (appid) DO NOTHING', [appId, details]);
     return result;
 }
 
@@ -111,6 +111,7 @@ async function snapshotCurrentAnalysis(client, appId) {
                 WHERE existing.appid = apps.appid
                     AND existing.analysed = COALESCE(apps.analysed, NOW())
             )
+        ON CONFLICT (appid, analysed) DO NOTHING
     `, [appId]);
 }
 
@@ -211,7 +212,7 @@ const updateAnalysis = async (appId, analysis, analysisVersion) => {
                     analysis_source,
                     success
                 )
-                SELECT
+                VALUES (
                     $1,
                     $2,
                     $3,
@@ -220,6 +221,8 @@ const updateAnalysis = async (appId, analysis, analysisVersion) => {
                     NULLIF($6, '')::timestamp,
                     $7,
                     $8
+                )
+                ON CONFLICT (appid, analysed) DO NOTHING
             `, [
                 appId,
                 analysis,
@@ -271,7 +274,7 @@ const getSiteDataSignature = async () => {
 }
 
 const countAnalysed = async () => {
-    const result = await pool.query("SELECT COUNT(*) FROM apps WHERE analysis IS NOT NULL AND analysis ->> 'success' != 'false'");
+    const result = await pool.query("SELECT COUNT(*) FROM apps WHERE analysis IS NOT NULL AND COALESCE(analysis->>'success', 'true') != 'false'");
     return parseInt(result.rows[0].count, 10);
 }
 


### PR DESCRIPTION
Well-scoped database fixes from a code review. No larger refactors (no status-column migration, no json→jsonb conversion, no case-insensitivity change).

## Fixes

- **`countAnalysed` undercount** (`models/Apps.js`): the predicate `analysis ->> 'success' != 'false'` evaluates to NULL when the `success` key is absent, silently excluding legacy successful analyses. Now uses `COALESCE(analysis->>'success', 'true') != 'false'`, matching `getSiteDataSignature`.
- **Duplicate-key race in `addApp`** (`models/Apps.js`): the route does find-then-insert with no conflict handling, so two concurrent first visits to the same app throw a duplicate-key 500. Added `ON CONFLICT (appid) DO NOTHING`.
- **New migration `migrations/006_app_analyses_unique.sql`**: removes duplicate `app_analyses` rows (keeping the lowest `id` per `(appid, analysed)`) and adds a `UNIQUE` index, backing the history-table dedupe that previously relied only on a race-prone `NOT EXISTS` guard.
- **History insert paths** (`snapshotCurrentAnalysis` and `updateAnalysis`): now use `ON CONFLICT (appid, analysed) DO NOTHING` so concurrent writers can't fail. The `updateAnalysis` history insert was also rewritten from a `SELECT` with no `FROM` to a plain `INSERT ... VALUES`.
- **New baseline migration `migrations/000_apps.sql`**: creates the `apps` table (`IF NOT EXISTS`, so a no-op on existing databases) so a fresh database can be bootstrapped with `node scripts/migrate.js`; with migrations as the canonical bootstrap, the runtime `historyTableExists()` probe (an extra `to_regclass` round-trip per write) was removed from `models/Apps.js`, and the README setup instructions now point at an empty database plus the migrate script.

## Testing

`npm test` — all 17 tests pass. Existing tests are pure unit tests with no pg mocking, so a DB-level regression test for the `countAnalysed` predicate was not feasible without new test infrastructure (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deployment note

⚠️ Run `node scripts/migrate.js` **before** deploying this code. The new `ON CONFLICT (appid, analysed)` clauses require the unique index created by migration 006 — on a database without it, Postgres rejects the statement ("no unique or exclusion constraint matching the ON CONFLICT specification"), which would break every analysis upload until the migration runs. In addition, the code no longer probes for the `app_analyses` table at runtime: it assumes migration 001 has been applied, so deploying without running migrations would make history writes fail outright.