### PR TITLE
Run migrations on startup for hands-off Railway deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "watch": "nodemon ./index.js",
-    "start": "node ./index.js",
+    "start": "node scripts/migrate.js && node ./index.js",
     "test": "node --test",
     "queue-status": "node scripts/queue-status.js",
     "priority-report": "node scripts/priority-report.js",


### PR DESCRIPTION
One-line change: `npm start` now runs `node scripts/migrate.js` before launching the server.

**Why:** Railway deploys automatically on merge to main, but nothing applied database migrations — PR #9 required a manual migration run against production before the deploy was safe. With this change, every deploy applies pending migrations first, so merge-to-main is fully hands-off.

**Safety:** `scripts/migrate.js` is idempotent — already-applied migrations are skipped via the `schema_migrations` ledger — so this is a no-op on ordinary restarts. If a migration fails, the process exits non-zero and the old deployment stays live rather than booting code against a mismatched schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)