### PR TITLE
Protect app search with Cloudflare Turnstile

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,16 @@ UPLOAD_PASSWORD=change-me
 CURRENT_ANALYSIS_VERSION=4
 BODY_LIMIT=25mb
 PUBLIC_FORM_BODY_LIMIT=100kb
+TURNSTILE_SECRET=change-me
+TURNSTILE_HOSTNAMES=ios.trackercontrol.org,localhost
+APP_STORE_CACHE_RETENTION_DAYS=90
 PORT=3000
 ```
 
 `BODY_LIMIT` applies to authenticated analyser JSON and text uploads.
 `PUBLIC_FORM_BODY_LIMIT` is the smaller limit for the public search form.
+`TURNSTILE_SECRET` and `TURNSTILE_HOSTNAMES` are required in production.
+`APP_STORE_CACHE_RETENTION_DAYS` controls how long cached App Store metadata is kept.
 
 Run migrations:
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,22 @@
 // .env saves configuration variables
 require('dotenv').config();
 
+const turnstile = require('./lib/turnstile');
+
 // Load the actual app
 const app = require('./server');
 
 // tell Express that we're behind a proxy (in production) so that it resolves internal URLs correctly
 var env = process.env.NODE_ENV || 'development';
-if (env == 'production')
-  app.enable('trust proxy');
+if (env == 'production') {
+  app.set('trust proxy', 1);
+  try {
+    turnstile.assertTurnstileConfiguration();
+  } catch (err) {
+    console.error(`Turnstile configuration error: ${err.message}`);
+    throw err;
+  }
+}
 
 // Server express HTTP server
 const port = process.env.PORT || 3000;

--- a/lib/turnstile.js
+++ b/lib/turnstile.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+const MAX_TOKEN_LENGTH = 2048;
+const SITEVERIFY_TIMEOUT_MS = 10_000;
+
+function parseExpectedHostnames(value) {
+  if (typeof value !== 'string') return new Set();
+
+  return new Set(value
+    .split(',')
+    .map((hostname) => hostname.trim())
+    .filter(Boolean));
+}
+
+async function validateTurnstile({
+  token,
+  remoteIp,
+  expectedAction,
+  secret = process.env.TURNSTILE_SECRET,
+  hostnames = process.env.TURNSTILE_HOSTNAMES,
+  fetchImpl = globalThis.fetch,
+}) {
+  const expectedHostnames = parseExpectedHostnames(hostnames);
+
+  if (typeof token !== 'string'
+      || token.length === 0
+      || token.length > MAX_TOKEN_LENGTH
+      || typeof secret !== 'string'
+      || secret.trim().length === 0
+      || typeof expectedAction !== 'string'
+      || expectedAction.length === 0
+      || expectedHostnames.size === 0
+      || typeof fetchImpl !== 'function') {
+    return false;
+  }
+
+  const body = new URLSearchParams({
+    secret,
+    response: token,
+  });
+  if (typeof remoteIp === 'string' && remoteIp.length > 0)
+    body.set('remoteip', remoteIp);
+
+  try {
+    const response = await fetchImpl(SITEVERIFY_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      signal: AbortSignal.timeout(SITEVERIFY_TIMEOUT_MS),
+      body,
+    });
+    if (!response.ok) return false;
+
+    const result = await response.json();
+    return result.success === true
+      && result.action === expectedAction
+      && expectedHostnames.has(result.hostname);
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  MAX_TOKEN_LENGTH,
+  SITEVERIFY_URL,
+  parseExpectedHostnames,
+  validateTurnstile,
+};

--- a/lib/turnstile.js
+++ b/lib/turnstile.js
@@ -4,6 +4,24 @@ const SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverif
 const MAX_TOKEN_LENGTH = 2048;
 const SITEVERIFY_TIMEOUT_MS = 10_000;
 
+function getTurnstileConfigurationError({
+  secret = process.env.TURNSTILE_SECRET,
+  hostnames = process.env.TURNSTILE_HOSTNAMES,
+} = {}) {
+  if (typeof secret !== 'string' || secret.trim().length === 0)
+    return 'TURNSTILE_SECRET is not set';
+
+  if (parseExpectedHostnames(hostnames).size === 0)
+    return 'TURNSTILE_HOSTNAMES is not set';
+
+  return null;
+}
+
+function assertTurnstileConfiguration(config) {
+  const error = getTurnstileConfigurationError(config);
+  if (error) throw new Error(error);
+}
+
 function parseExpectedHostnames(value) {
   if (typeof value !== 'string') return new Set();
 
@@ -20,17 +38,22 @@ async function validateTurnstile({
   secret = process.env.TURNSTILE_SECRET,
   hostnames = process.env.TURNSTILE_HOSTNAMES,
   fetchImpl = globalThis.fetch,
+  logger = console,
 }) {
   const expectedHostnames = parseExpectedHostnames(hostnames);
+
+  const configurationError = getTurnstileConfigurationError({ secret, hostnames });
+  if (configurationError) {
+    if (logger && typeof logger.error === 'function')
+      logger.error(`Turnstile configuration error: ${configurationError}`);
+    return false;
+  }
 
   if (typeof token !== 'string'
       || token.length === 0
       || token.length > MAX_TOKEN_LENGTH
-      || typeof secret !== 'string'
-      || secret.trim().length === 0
       || typeof expectedAction !== 'string'
       || expectedAction.length === 0
-      || expectedHostnames.size === 0
       || typeof fetchImpl !== 'function') {
     return false;
   }
@@ -63,6 +86,8 @@ async function validateTurnstile({
 module.exports = {
   MAX_TOKEN_LENGTH,
   SITEVERIFY_URL,
+  assertTurnstileConfiguration,
+  getTurnstileConfigurationError,
   parseExpectedHostnames,
   validateTurnstile,
 };

--- a/migrations/011_app_store_cache.sql
+++ b/migrations/011_app_store_cache.sql
@@ -1,0 +1,9 @@
+-- Cache App Store search metadata separately from apps. A cache entry does not
+-- enqueue an analysis; a later search refreshes the stored metadata.
+
+CREATE TABLE app_store_cache (
+    appid_key text PRIMARY KEY,
+    details jsonb NOT NULL,
+    fetched_at timestamptz NOT NULL DEFAULT NOW(),
+    CONSTRAINT app_store_cache_lowercase_key CHECK (appid_key = lower(appid_key))
+);

--- a/migrations/012_app_store_cache_retention.sql
+++ b/migrations/012_app_store_cache_retention.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS app_store_cache_fetched_at_idx
+    ON app_store_cache (fetched_at);

--- a/models/Apps.js
+++ b/models/Apps.js
@@ -76,6 +76,45 @@ const findApp = async (appId) => {
     return result.rows[0];
 }
 
+function buildAppStoreCacheUpsert(results) {
+    const entries = (results || []).filter((details) =>
+        details && isValidAppId(details.appId)
+    );
+    if (entries.length === 0) return null;
+
+    const values = [];
+    const placeholders = entries.map((details, index) => {
+        values.push(details.appId.toLowerCase(), details);
+        return `($${index * 2 + 1}, $${index * 2 + 2})`;
+    });
+
+    return {
+        text: `
+        INSERT INTO app_store_cache (appid_key, details)
+        VALUES ${placeholders.join(', ')}
+        ON CONFLICT (appid_key) DO UPDATE
+        SET details = EXCLUDED.details,
+            fetched_at = NOW()
+    `,
+        values
+    };
+}
+
+const cacheAppStoreResults = async (results) => {
+    const query = buildAppStoreCacheUpsert(results);
+    if (query) await pool.query(query.text, query.values);
+}
+
+const findCachedAppStoreResult = async (appId) => {
+    if (!isValidAppId(appId)) return null;
+
+    const result = await pool.query(
+        'SELECT details FROM app_store_cache WHERE appid_key = lower($1)',
+        [appId]
+    );
+    return result.rows.length === 0 ? null : result.rows[0].details;
+}
+
 const countQueue = async (added) => {
     if (added) {
         const result = await pool.query(`
@@ -311,6 +350,8 @@ const countAnalysed = async () => {
 module.exports = {
     lastAnalysed,
     findApp,
+    cacheAppStoreResults,
+    findCachedAppStoreResult,
     countQueue,
     countAnalysed,
     addApp,
@@ -321,6 +362,7 @@ module.exports = {
     healthCheck,
     deriveAnalysisState,
     canonicalAppId,
+    buildAppStoreCacheUpsert,
     isValidAnalysisClaimToken,
     updateAnalysisWithClient
 }

--- a/models/Apps.js
+++ b/models/Apps.js
@@ -20,6 +20,15 @@ const pool = new Pool(
         : {}
 );
 
+const configuredCacheRetentionDays = Number.parseInt(
+    process.env.APP_STORE_CACHE_RETENTION_DAYS || '90',
+    10
+);
+const APP_STORE_CACHE_RETENTION_DAYS = Number.isInteger(configuredCacheRetentionDays)
+    && configuredCacheRetentionDays > 0
+    ? configuredCacheRetentionDays
+    : 90;
+
 pool.on('error', (err) => {
     console.error('Unexpected PostgreSQL pool error:', err.message);
 });
@@ -77,14 +86,18 @@ const findApp = async (appId) => {
 }
 
 function buildAppStoreCacheUpsert(results) {
-    const entries = (results || []).filter((details) =>
-        details && isValidAppId(details.appId)
-    );
+    const entriesByKey = new Map();
+    for (const details of results || []) {
+        if (!details || !isValidAppId(details.appId)) continue;
+        entriesByKey.set(details.appId.toLowerCase(), details);
+    }
+
+    const entries = [...entriesByKey.entries()];
     if (entries.length === 0) return null;
 
     const values = [];
-    const placeholders = entries.map((details, index) => {
-        values.push(details.appId.toLowerCase(), details);
+    const placeholders = entries.map(([appidKey, details], index) => {
+        values.push(appidKey, details);
         return `($${index * 2 + 1}, $${index * 2 + 2})`;
     });
 
@@ -100,9 +113,22 @@ function buildAppStoreCacheUpsert(results) {
     };
 }
 
+function buildAppStoreCachePrune() {
+    return {
+        text: `
+        DELETE FROM app_store_cache
+        WHERE fetched_at < NOW() - ($1::integer * INTERVAL '1 day')
+    `,
+        values: [APP_STORE_CACHE_RETENTION_DAYS]
+    };
+}
+
 const cacheAppStoreResults = async (results) => {
     const query = buildAppStoreCacheUpsert(results);
     if (query) await pool.query(query.text, query.values);
+
+    const prune = buildAppStoreCachePrune();
+    await pool.query(prune.text, prune.values);
 }
 
 const findCachedAppStoreResult = async (appId) => {
@@ -362,7 +388,9 @@ module.exports = {
     healthCheck,
     deriveAnalysisState,
     canonicalAppId,
+    APP_STORE_CACHE_RETENTION_DAYS,
     buildAppStoreCacheUpsert,
+    buildAppStoreCachePrune,
     isValidAnalysisClaimToken,
     updateAnalysisWithClient
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -205,16 +205,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1927,9 +1927,9 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "requires": {
         "bytes": "~3.1.2",
         "content-type": "~1.0.5",
@@ -1965,9 +1965,9 @@
       }
     },
     "brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "requires": {
         "balanced-match": "^4.0.2"

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -2,6 +2,18 @@ body {
   /*padding: 40px 10px;*/
   background-color: #eee;
 }
+.navbar-search-form {
+  flex-wrap: wrap;
+}
+@media (max-width: 991.98px) {
+  .navbar-search-form {
+    flex: 1 0 100%;
+    order: 3;
+  }
+  .navbar-search-form input {
+    flex: 1 1 auto;
+  }
+}
 .listing-reg h1 {
   text-align: center;
   margin: 0 0 2rem;

--- a/routes/index.js
+++ b/routes/index.js
@@ -23,12 +23,27 @@ let lastPing = 0; // unix timestamp
 
 function requireTurnstile(expectedAction) {
   return asyncHandler(async (req, res, next) => {
+    const configurationError = turnstile.getTurnstileConfigurationError();
+    if (configurationError) {
+      console.error(`Turnstile configuration error: ${configurationError}`);
+      return renderTurnstileFailure(req, res, expectedAction, {
+        status: 503,
+        error: 'Security verification is temporarily unavailable. Please try again later.',
+      });
+    }
+
     const valid = await turnstile.validateTurnstile({
       token: req.body['cf-turnstile-response'],
       remoteIp: req.ip,
       expectedAction,
     });
-    if (!valid) return res.status(403).send('forbidden');
+    if (!valid) {
+      console.warn(`Turnstile token validation failed for action: ${expectedAction}`);
+      return renderTurnstileFailure(req, res, expectedAction, {
+        status: 403,
+        error: 'The security check expired or failed. Please try again.',
+      });
+    }
 
     return next();
   });
@@ -47,6 +62,18 @@ function renderAnalysisRequest(res, appId, { status = 200, error = null } = {}) 
     title: 'Request app analysis',
     appId,
     error,
+  });
+}
+
+function renderTurnstileFailure(req, res, expectedAction, { status, error }) {
+  if (expectedAction === 'request_analysis') {
+    return renderAnalysisRequest(res, req.params.appId, { status, error });
+  }
+
+  return res.status(status).render('form', {
+    title: 'Search app',
+    errors: [{ msg: error }],
+    data: { search: req.body && req.body.search },
   });
 }
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,6 +8,7 @@ const cache = require('../lib/cache');
 const { isValidAppId } = require('../lib/appId');
 const { classifyAnalysisFailure } = require('../lib/analysisFailure');
 const asyncHandler = require('../lib/asyncHandler');
+const turnstile = require('../lib/turnstile');
 
 // Taken from https://reports.exodus-privacy.eu.org/api/trackers
 const exodusTrackers = JSON.parse(fs.readFileSync('./exodusTrackers.json', 'utf-8'))
@@ -220,6 +221,16 @@ router.get('/healthz/analyser', (req, res) => {
 });
 
 router.post('/search',
+  asyncHandler(async (req, res, next) => {
+    const valid = await turnstile.validateTurnstile({
+      token: req.body['cf-turnstile-response'],
+      remoteIp: req.ip,
+      expectedAction: 'search_app',
+    });
+    if (!valid) return res.status(403).send('forbidden');
+
+    return next();
+  }),
   [
     check('search')
       .isLength({ min: 1 })

--- a/routes/index.js
+++ b/routes/index.js
@@ -21,6 +21,35 @@ const COUNTRY = 'gb';
 
 let lastPing = 0; // unix timestamp
 
+function requireTurnstile(expectedAction) {
+  return asyncHandler(async (req, res, next) => {
+    const valid = await turnstile.validateTurnstile({
+      token: req.body['cf-turnstile-response'],
+      remoteIp: req.ip,
+      expectedAction,
+    });
+    if (!valid) return res.status(403).send('forbidden');
+
+    return next();
+  });
+}
+
+function requireValidAppId(req, res, next) {
+  if (!isValidAppId(req.params.appId))
+    return res.status(400).send('Please provide a valid App Store bundle ID.');
+
+  return next();
+}
+
+function renderAnalysisRequest(res, appId, { status = 200, error = null } = {}) {
+  res.set('X-Robots-Tag', 'noindex');
+  return res.status(status).render('request-analysis', {
+    title: 'Request app analysis',
+    appId,
+    error,
+  });
+}
+
 // ping from analyser in past hour?
 router.use(function (req, res, next) {
   res.locals.analyserOnline = lastPing > Date.now() - 1000*60*60;
@@ -221,16 +250,7 @@ router.get('/healthz/analyser', (req, res) => {
 });
 
 router.post('/search',
-  asyncHandler(async (req, res, next) => {
-    const valid = await turnstile.validateTurnstile({
-      token: req.body['cf-turnstile-response'],
-      remoteIp: req.ip,
-      expectedAction: 'search_app',
-    });
-    if (!valid) return res.status(403).send('forbidden');
-
-    return next();
-  }),
+  requireTurnstile('search_app'),
   [
     check('search')
       .isLength({ min: 1 })
@@ -246,12 +266,20 @@ router.post('/search',
           num: 5,
           country : COUNTRY,
         });
+        await Apps.cacheAppStoreResults(result);
+        const existingApps = await Promise.all(result.map((app) =>
+          app.free ? Apps.findApp(app.appId) : null
+        ));
+        const searchResults = result.map((app, index) => ({
+          ...app,
+          inDatabase: Boolean(existingApps[index]),
+        }));
 
         res.render('form', {
           title: 'Search app',
           errors: errors.array(),
           data: req.body,
-          searchResults: result
+          searchResults
         });
       } catch (err) {
         console.log(err);
@@ -266,61 +294,32 @@ router.post('/search',
     };
 }));
 
-router.get('/analysis/:appId', asyncHandler(async (req, res) => {
-  if (!isValidAppId(req.params.appId))
-    return res.status(400).send('Please provide a valid App Store bundle ID.');
+router.get('/analysis/:appId', requireValidAppId, asyncHandler(async (req, res) => {
   let appId = req.params.appId;
 
   console.log('Fetching', appId);
 
   let app = await Apps.findApp(appId);
-  if (app) {
-    if (app.analysis) {
-      const analysis = app.analysis;
+  if (!app) return renderAnalysisRequest(res, appId);
 
-      if (analysis.success !== undefined && analysis.success === false)
-        app.analysisFailure = analysis.reason === 'app_not_found' ? "App not found on App Store." : "Analysis failed."
-      else {
-        if (analysis.trackers)
-          app.trackers = "Found trackers: " + Object.keys(analysis.trackers).join(", ");
-        else
-          app.trackers = "No trackers found."
+  if (app.analysis) {
+    const analysis = app.analysis;
 
-        if (analysis.permissions)
-          app.permissions = "Can request permissions: " + analysis.permissions.join(", ");
-        else
-          app.permissions = "No permissions can be requested by app."
-      }
-    } else
-      app.queueCount = await Apps.countQueue(app.added);
-  } else {
-    app = {};
-    app.queueCount = await Apps.countQueue();
+    if (analysis.success !== undefined && analysis.success === false)
+      app.analysisFailure = analysis.reason === 'app_not_found' ? "App not found on App Store." : "Analysis failed."
+    else {
+      if (analysis.trackers)
+        app.trackers = "Found trackers: " + Object.keys(analysis.trackers).join(", ");
+      else
+        app.trackers = "No trackers found."
 
-    try {
-        // Retrieve information about apps from App Store
-        app.details = await store.app({appId: appId, country: COUNTRY});
-      } catch (err) {
-        console.log(err);
-
-        if (String(err).includes("App not found (404)"))
-          return res.status(404).send('App not found on App Store.');
-        else
-          return res.status(500).send('Downloading of app information failed. Please try again later.');
-      }
-
-      if (!app.details.free)
-        return res.status(400).send('Can\'t analyse non-free apps.');
-
-      // Save to database
-      try {
-        await Apps.addApp(appId, app.details);
-      } catch (err) {
-        console.log(err);
-
-        return res.status(500).send('Error adding app. Please try again later.');
-      }
-  }
+      if (analysis.permissions)
+        app.permissions = "Can request permissions: " + analysis.permissions.join(", ");
+      else
+        app.permissions = "No permissions can be requested by app."
+    }
+  } else
+    app.queueCount = await Apps.countQueue(app.added);
 
   // Compute jurisdiction analysis if trackers exist
   let jurisdictionData = null;
@@ -338,6 +337,55 @@ router.get('/analysis/:appId', asyncHandler(async (req, res) => {
     jurisdictionData: jurisdictionData
   });
 }));
+
+router.post('/analysis/:appId',
+  requireValidAppId,
+  requireTurnstile('request_analysis'),
+  asyncHandler(async (req, res) => {
+    const requestedAppId = req.params.appId;
+    const existing = await Apps.findApp(requestedAppId);
+    if (existing)
+      return res.redirect(303, `/analysis/${existing.appid}`);
+
+    let details = await Apps.findCachedAppStoreResult(requestedAppId);
+    if (!details) {
+      try {
+        details = await store.app({ appId: requestedAppId, country: COUNTRY });
+      } catch (err) {
+        console.log(err);
+
+        if (String(err).includes('App not found (404)')) {
+          return renderAnalysisRequest(res, requestedAppId, {
+            status: 404,
+            error: 'App not found on App Store.',
+          });
+        }
+        return renderAnalysisRequest(res, requestedAppId, {
+          status: 502,
+          error: 'Downloading of app information failed. Please try again later.',
+        });
+      }
+    }
+
+    if (!details.free) {
+      return renderAnalysisRequest(res, requestedAppId, {
+        status: 400,
+        error: 'Can\'t analyse non-free apps.',
+      });
+    }
+
+    try {
+      await Apps.addApp(requestedAppId, details);
+    } catch (err) {
+      console.log(err);
+      return renderAnalysisRequest(res, requestedAppId, {
+        status: 500,
+        error: 'Error adding app. Please try again later.',
+      });
+    }
+
+    return res.redirect(303, `/analysis/${details.appId}`);
+  }));
 
 // About page
 router.get('/about', (req, res) => {

--- a/server.js
+++ b/server.js
@@ -72,6 +72,10 @@ app.post('/search', bodyParser.urlencoded({
   extended: true,
   limit: publicFormBodyLimit
 }));
+app.post('/analysis/:appId', bodyParser.urlencoded({
+  extended: true,
+  limit: publicFormBodyLimit
+}));
 app.post('/uploadAnalysis', bodyParser.json({ limit: analyserBodyLimit }));
 app.post('/reportAnalysisFailure', express.text({ limit: analyserBodyLimit }));
 

--- a/server.js
+++ b/server.js
@@ -16,6 +16,9 @@ app.use(helmet({
     directives: {
       ...helmet.contentSecurityPolicy.getDefaultDirectives(),
       "img-src": ["'self'", "*.mzstatic.com"],
+      "script-src": ["'self'", "https://challenges.cloudflare.com"],
+      "connect-src": ["'self'", "https://challenges.cloudflare.com"],
+      "frame-src": ["'self'", "https://challenges.cloudflare.com"],
     },
   },
   crossOriginEmbedderPolicy: false

--- a/test/appStoreCache.test.js
+++ b/test/appStoreCache.test.js
@@ -2,7 +2,11 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const { buildAppStoreCacheUpsert } = require('../models/Apps');
+const {
+  APP_STORE_CACHE_RETENTION_DAYS,
+  buildAppStoreCachePrune,
+  buildAppStoreCacheUpsert,
+} = require('../models/Apps');
 
 test('App Store cache upsert normalizes keys and retains full metadata', () => {
   const details = {
@@ -25,4 +29,20 @@ test('App Store cache upsert skips malformed bundle IDs', () => {
   ]);
 
   assert.equal(query, null);
+});
+
+test('App Store cache upsert deduplicates case-insensitive bundle IDs', () => {
+  const first = { appId: 'com.example.Cached', title: 'First' };
+  const second = { appId: 'COM.EXAMPLE.CACHED', title: 'Last' };
+  const query = buildAppStoreCacheUpsert([first, second]);
+
+  assert.deepEqual(query.values, ['com.example.cached', second]);
+  assert.equal((query.text.match(/\$1/g) || []).length, 1);
+});
+
+test('App Store cache pruning uses the configured retention window', () => {
+  const query = buildAppStoreCachePrune();
+
+  assert.match(query.text, /fetched_at < NOW\(\) - \(\$1::integer \* INTERVAL '1 day'\)/);
+  assert.deepEqual(query.values, [APP_STORE_CACHE_RETENTION_DAYS]);
 });

--- a/test/appStoreCache.test.js
+++ b/test/appStoreCache.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { buildAppStoreCacheUpsert } = require('../models/Apps');
+
+test('App Store cache upsert normalizes keys and retains full metadata', () => {
+  const details = {
+    appId: 'com.example.Cached',
+    title: 'Cached App',
+    icon: 'https://example.test/icon.png',
+    free: true,
+  };
+
+  const query = buildAppStoreCacheUpsert([details]);
+
+  assert.match(query.text, /ON CONFLICT \(appid_key\) DO UPDATE/);
+  assert.deepEqual(query.values, ['com.example.cached', details]);
+});
+
+test('App Store cache upsert skips malformed bundle IDs', () => {
+  const query = buildAppStoreCacheUpsert([
+    { appId: 'invalid/id', title: 'Invalid' },
+    null,
+  ]);
+
+  assert.equal(query, null);
+});

--- a/test/requestHandling.test.js
+++ b/test/requestHandling.test.js
@@ -3,6 +3,8 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 const Apps = require('../models/Apps');
+const store = require('../lib/appStore');
+const turnstile = require('../lib/turnstile');
 
 process.env.UPLOAD_PASSWORD = 'test-secret';
 process.env.BODY_LIMIT = '2kb';
@@ -142,4 +144,87 @@ test('large body parsers are scoped to authenticated analyser endpoints', async 
     Apps.updateAnalysis = originalUpdateAnalysis;
     console.log = originalConsoleLog;
   }
+});
+
+test('search rejects requests that fail Turnstile validation', async () => {
+  const originalValidateTurnstile = turnstile.validateTurnstile;
+  const originalSearch = store.search;
+  let validationInput;
+  let searchCalled = false;
+
+  turnstile.validateTurnstile = async (input) => {
+    validationInput = input;
+    return false;
+  };
+  store.search = async () => {
+    searchCalled = true;
+    return [];
+  };
+
+  try {
+    await withServer(async (base) => {
+      const response = await fetch(`${base}/search`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: 'search=test&cf-turnstile-response=invalid-token'
+      });
+
+      assert.equal(response.status, 403);
+      assert.equal(await response.text(), 'forbidden');
+    });
+
+    assert.equal(validationInput.token, 'invalid-token');
+    assert.equal(validationInput.expectedAction, 'search_app');
+    assert.match(validationInput.remoteIp, /127\.0\.0\.1/);
+    assert.equal(searchCalled, false);
+  } finally {
+    turnstile.validateTurnstile = originalValidateTurnstile;
+    store.search = originalSearch;
+  }
+});
+
+test('search continues after successful Turnstile validation', async () => {
+  const originalValidateTurnstile = turnstile.validateTurnstile;
+  const originalSearch = store.search;
+  let searchInput;
+
+  turnstile.validateTurnstile = async () => true;
+  store.search = async (input) => {
+    searchInput = input;
+    return [];
+  };
+
+  try {
+    await withServer(async (base) => {
+      const response = await fetch(`${base}/search`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: 'search=test&cf-turnstile-response=valid-token'
+      });
+
+      assert.equal(response.status, 200);
+    });
+
+    assert.deepEqual(searchInput, { term: 'test', num: 5, country: 'gb' });
+  } finally {
+    turnstile.validateTurnstile = originalValidateTurnstile;
+    store.search = originalSearch;
+  }
+});
+
+test('public pages load the Turnstile widget with compatible CSP directives', async () => {
+  await withServer(async (base) => {
+    const response = await fetch(`${base}/about`);
+    const html = await response.text();
+    const csp = response.headers.get('content-security-policy');
+
+    assert.equal(response.status, 200);
+    assert.match(csp, /script-src 'self' https:\/\/challenges\.cloudflare\.com/);
+    assert.match(csp, /connect-src 'self' https:\/\/challenges\.cloudflare\.com/);
+    assert.match(csp, /frame-src 'self' https:\/\/challenges\.cloudflare\.com/);
+    assert.match(html, /https:\/\/challenges\.cloudflare\.com\/turnstile\/v0\/api\.js/);
+    assert.match(html, /data-sitekey="0x4AAAAAAEM-nOb30hisDzEI"/);
+    assert.match(html, /data-action="search_app"/);
+    assert.match(html, /data-appearance="interaction-only"/);
+  });
 });

--- a/test/requestHandling.test.js
+++ b/test/requestHandling.test.js
@@ -9,6 +9,8 @@ const turnstile = require('../lib/turnstile');
 process.env.UPLOAD_PASSWORD = 'test-secret';
 process.env.BODY_LIMIT = '2kb';
 process.env.PUBLIC_FORM_BODY_LIMIT = '100b';
+process.env.TURNSTILE_SECRET = 'test-turnstile-secret';
+process.env.TURNSTILE_HOSTNAMES = '127.0.0.1,localhost';
 
 const app = require('../server');
 
@@ -170,7 +172,9 @@ test('search rejects requests that fail Turnstile validation', async () => {
       });
 
       assert.equal(response.status, 403);
-      assert.equal(await response.text(), 'forbidden');
+      const html = await response.text();
+      assert.match(html, /The security check expired or failed\. Please try again\./);
+      assert.match(html, /data-action="search_app"/);
     });
 
     assert.equal(validationInput.token, 'invalid-token');
@@ -313,7 +317,9 @@ test('analysis request rejects invalid Turnstile before contacting Apple', async
       });
 
       assert.equal(response.status, 403);
-      assert.equal(await response.text(), 'forbidden');
+      const html = await response.text();
+      assert.match(html, /The security check expired or failed\. Please try again\./);
+      assert.match(html, /data-action="request_analysis"/);
     });
     assert.equal(validationInput.token, 'invalid-token');
     assert.equal(validationInput.expectedAction, 'request_analysis');

--- a/test/requestHandling.test.js
+++ b/test/requestHandling.test.js
@@ -186,12 +186,36 @@ test('search rejects requests that fail Turnstile validation', async () => {
 test('search continues after successful Turnstile validation', async () => {
   const originalValidateTurnstile = turnstile.validateTurnstile;
   const originalSearch = store.search;
+  const originalFindApp = Apps.findApp;
+  const originalCacheAppStoreResults = Apps.cacheAppStoreResults;
   let searchInput;
+  let cachedResults;
 
   turnstile.validateTurnstile = async () => true;
   store.search = async (input) => {
     searchInput = input;
-    return [];
+    return [
+      {
+        appId: 'com.example.known',
+        title: 'Known App',
+        icon: 'https://example.test/known.png',
+        version: '1.0',
+        free: true,
+      },
+      {
+        appId: 'com.example.unknown',
+        title: 'Unknown App',
+        icon: 'https://example.test/unknown.png',
+        version: '2.0',
+        free: true,
+      },
+    ];
+  };
+  Apps.findApp = async (appId) => appId === 'com.example.known'
+    ? { appid: appId }
+    : null;
+  Apps.cacheAppStoreResults = async (results) => {
+    cachedResults = results;
   };
 
   try {
@@ -203,12 +227,20 @@ test('search continues after successful Turnstile validation', async () => {
       });
 
       assert.equal(response.status, 200);
+      const html = await response.text();
+      assert.match(html, /href="\/analysis\/com\.example\.known"/);
+      assert.match(html, /formaction="\/analysis\/com\.example\.unknown"/);
+      assert.match(html, /data-action="request_analysis"/);
     });
 
     assert.deepEqual(searchInput, { term: 'test', num: 5, country: 'gb' });
+    assert.equal(cachedResults.length, 2);
+    assert.equal(cachedResults[1].appId, 'com.example.unknown');
   } finally {
     turnstile.validateTurnstile = originalValidateTurnstile;
     store.search = originalSearch;
+    Apps.findApp = originalFindApp;
+    Apps.cacheAppStoreResults = originalCacheAppStoreResults;
   }
 });
 
@@ -227,4 +259,160 @@ test('public pages load the Turnstile widget with compatible CSP directives', as
     assert.match(html, /data-action="search_app"/);
     assert.match(html, /data-appearance="interaction-only"/);
   });
+});
+
+test('unknown app GET is database-only and renders an analysis request form', async () => {
+  const originalFindApp = Apps.findApp;
+  const originalStoreApp = store.app;
+  let storeAppCalled = false;
+
+  Apps.findApp = async () => null;
+  store.app = async () => {
+    storeAppCalled = true;
+    throw new Error('should not be called');
+  };
+
+  try {
+    await withServer(async (base) => {
+      const response = await fetch(`${base}/analysis/com.example.unknown`);
+      const html = await response.text();
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('x-robots-tag'), 'noindex');
+      assert.match(html, /data-action="request_analysis"/);
+      assert.match(html, /action="\/analysis\/com\.example\.unknown" method="POST"/);
+    });
+    assert.equal(storeAppCalled, false);
+  } finally {
+    Apps.findApp = originalFindApp;
+    store.app = originalStoreApp;
+  }
+});
+
+test('analysis request rejects invalid Turnstile before contacting Apple', async () => {
+  const originalValidateTurnstile = turnstile.validateTurnstile;
+  const originalStoreApp = store.app;
+  let validationInput;
+  let storeAppCalled = false;
+
+  turnstile.validateTurnstile = async (input) => {
+    validationInput = input;
+    return false;
+  };
+  store.app = async () => {
+    storeAppCalled = true;
+    throw new Error('should not be called');
+  };
+
+  try {
+    await withServer(async (base) => {
+      const response = await fetch(`${base}/analysis/com.example.unknown`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: 'cf-turnstile-response=invalid-token'
+      });
+
+      assert.equal(response.status, 403);
+      assert.equal(await response.text(), 'forbidden');
+    });
+    assert.equal(validationInput.token, 'invalid-token');
+    assert.equal(validationInput.expectedAction, 'request_analysis');
+    assert.equal(storeAppCalled, false);
+  } finally {
+    turnstile.validateTurnstile = originalValidateTurnstile;
+    store.app = originalStoreApp;
+  }
+});
+
+test('valid analysis request looks up, queues, and redirects to the canonical app', async () => {
+  const originalValidateTurnstile = turnstile.validateTurnstile;
+  const originalFindApp = Apps.findApp;
+  const originalAddApp = Apps.addApp;
+  const originalFindCachedAppStoreResult = Apps.findCachedAppStoreResult;
+  const originalStoreApp = store.app;
+  let added;
+
+  turnstile.validateTurnstile = async () => true;
+  Apps.findApp = async () => null;
+  Apps.findCachedAppStoreResult = async () => null;
+  Apps.addApp = async (...args) => {
+    added = args;
+    return { rowCount: 1 };
+  };
+  store.app = async () => ({
+    appId: 'com.example.Canonical',
+    title: 'Example App',
+    free: true,
+  });
+
+  try {
+    await withServer(async (base) => {
+      const response = await fetch(`${base}/analysis/com.example.canonical`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: 'cf-turnstile-response=valid-token',
+        redirect: 'manual'
+      });
+
+      assert.equal(response.status, 303);
+      assert.equal(response.headers.get('location'), '/analysis/com.example.Canonical');
+    });
+    assert.equal(added[0], 'com.example.canonical');
+    assert.equal(added[1].appId, 'com.example.Canonical');
+  } finally {
+    turnstile.validateTurnstile = originalValidateTurnstile;
+    Apps.findApp = originalFindApp;
+    Apps.addApp = originalAddApp;
+    Apps.findCachedAppStoreResult = originalFindCachedAppStoreResult;
+    store.app = originalStoreApp;
+  }
+});
+
+test('analysis request reuses Apple metadata cached by search', async () => {
+  const originalValidateTurnstile = turnstile.validateTurnstile;
+  const originalFindApp = Apps.findApp;
+  const originalAddApp = Apps.addApp;
+  const originalFindCachedAppStoreResult = Apps.findCachedAppStoreResult;
+  const originalStoreApp = store.app;
+  let added;
+  let storeAppCalled = false;
+
+  const cachedDetails = {
+    appId: 'com.example.Cached',
+    title: 'Cached App',
+    free: true,
+  };
+  turnstile.validateTurnstile = async () => true;
+  Apps.findApp = async () => null;
+  Apps.findCachedAppStoreResult = async () => cachedDetails;
+  Apps.addApp = async (...args) => {
+    added = args;
+    return { rowCount: 1 };
+  };
+  store.app = async () => {
+    storeAppCalled = true;
+    throw new Error('should not be called');
+  };
+
+  try {
+    await withServer(async (base) => {
+      const response = await fetch(`${base}/analysis/com.example.cached`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: 'cf-turnstile-response=valid-token',
+        redirect: 'manual'
+      });
+
+      assert.equal(response.status, 303);
+      assert.equal(response.headers.get('location'), '/analysis/com.example.Cached');
+    });
+    assert.equal(added[1].title, 'Cached App');
+    assert.equal(storeAppCalled, false);
+  } finally {
+    turnstile.validateTurnstile = originalValidateTurnstile;
+    Apps.findApp = originalFindApp;
+    Apps.addApp = originalAddApp;
+    Apps.findCachedAppStoreResult = originalFindCachedAppStoreResult;
+    store.app = originalStoreApp;
+  }
 });

--- a/test/turnstile.test.js
+++ b/test/turnstile.test.js
@@ -5,9 +5,26 @@ const test = require('node:test');
 const {
   MAX_TOKEN_LENGTH,
   SITEVERIFY_URL,
+  assertTurnstileConfiguration,
+  getTurnstileConfigurationError,
   parseExpectedHostnames,
   validateTurnstile,
 } = require('../lib/turnstile');
+
+test('Turnstile configuration reports missing production variables', () => {
+  assert.equal(
+    getTurnstileConfigurationError({ secret: '', hostnames: 'localhost' }),
+    'TURNSTILE_SECRET is not set'
+  );
+  assert.equal(
+    getTurnstileConfigurationError({ secret: 'secret', hostnames: '' }),
+    'TURNSTILE_HOSTNAMES is not set'
+  );
+  assert.throws(
+    () => assertTurnstileConfiguration({ secret: '', hostnames: 'localhost' }),
+    /TURNSTILE_SECRET is not set/
+  );
+});
 
 test('parseExpectedHostnames trims entries and drops empty values', () => {
   assert.deepEqual(

--- a/test/turnstile.test.js
+++ b/test/turnstile.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  MAX_TOKEN_LENGTH,
+  SITEVERIFY_URL,
+  parseExpectedHostnames,
+  validateTurnstile,
+} = require('../lib/turnstile');
+
+test('parseExpectedHostnames trims entries and drops empty values', () => {
+  assert.deepEqual(
+    [...parseExpectedHostnames(' ios.trackercontrol.org, localhost, ,')],
+    ['ios.trackercontrol.org', 'localhost']
+  );
+});
+
+test('validateTurnstile verifies the token, action, hostname, and remote IP', async () => {
+  let request;
+  const valid = await validateTurnstile({
+    token: 'valid-token',
+    remoteIp: '203.0.113.10',
+    expectedAction: 'search_app',
+    secret: 'secret',
+    hostnames: 'ios.trackercontrol.org,localhost',
+    fetchImpl: async (url, options) => {
+      request = { url, options };
+      return {
+        ok: true,
+        json: async () => ({
+          success: true,
+          action: 'search_app',
+          hostname: 'ios.trackercontrol.org',
+        }),
+      };
+    },
+  });
+
+  assert.equal(valid, true);
+  assert.equal(request.url, SITEVERIFY_URL);
+  assert.equal(request.options.method, 'POST');
+  assert.equal(request.options.headers['Content-Type'], 'application/x-www-form-urlencoded');
+  assert.equal(request.options.body.get('secret'), 'secret');
+  assert.equal(request.options.body.get('response'), 'valid-token');
+  assert.equal(request.options.body.get('remoteip'), '203.0.113.10');
+  assert.ok(request.options.signal instanceof AbortSignal);
+});
+
+test('validateTurnstile fails closed before calling Siteverify for invalid configuration', async () => {
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls++;
+    throw new Error('should not be called');
+  };
+  const base = {
+    token: 'token',
+    expectedAction: 'search_app',
+    secret: 'secret',
+    hostnames: 'ios.trackercontrol.org',
+    fetchImpl,
+  };
+
+  assert.equal(await validateTurnstile({ ...base, token: '' }), false);
+  assert.equal(await validateTurnstile({ ...base, token: 'x'.repeat(MAX_TOKEN_LENGTH + 1) }), false);
+  assert.equal(await validateTurnstile({ ...base, secret: '' }), false);
+  assert.equal(await validateTurnstile({ ...base, hostnames: '' }), false);
+  assert.equal(await validateTurnstile({ ...base, expectedAction: '' }), false);
+  assert.equal(calls, 0);
+});
+
+test('validateTurnstile rejects an unexpected action or hostname', async () => {
+  const result = {
+    success: true,
+    action: 'different_action',
+    hostname: 'attacker.example',
+  };
+  const fetchImpl = async () => ({ ok: true, json: async () => result });
+  const base = {
+    token: 'token',
+    expectedAction: 'search_app',
+    secret: 'secret',
+    hostnames: 'ios.trackercontrol.org',
+    fetchImpl,
+  };
+
+  assert.equal(await validateTurnstile(base), false);
+  result.action = 'search_app';
+  assert.equal(await validateTurnstile(base), false);
+  result.hostname = 'ios.trackercontrol.org';
+  assert.equal(await validateTurnstile(base), true);
+});
+
+test('validateTurnstile rejects Siteverify errors and unsuccessful responses', async () => {
+  const base = {
+    token: 'token',
+    expectedAction: 'search_app',
+    secret: 'secret',
+    hostnames: 'ios.trackercontrol.org',
+  };
+
+  assert.equal(await validateTurnstile({
+    ...base,
+    fetchImpl: async () => ({ ok: false }),
+  }), false);
+  assert.equal(await validateTurnstile({
+    ...base,
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({ success: false }),
+    }),
+  }), false);
+  assert.equal(await validateTurnstile({
+    ...base,
+    fetchImpl: async () => { throw new Error('network unavailable'); },
+  }), false);
+});

--- a/views/form.pug
+++ b/views/form.pug
@@ -68,23 +68,36 @@ block content
   if searchResults
     h2 Found apps
 
-    #results
-      .container
-        for app in searchResults
-          .row.position-relative
-            .col-3.col-sm-2.col-md-2.my-auto
-              img.rounded(src=`${app.icon}` alt=`${app.appId} logo` width='50' height='50')
-            .col-9.col-sm-10.col-md-10.text-truncate.position-static
-              div
-                if app.free
-                  a.stretched-link.report-link(href=`/analysis/${app.appId}`)
-                    | #{app.title}
-                else
-                  a.text-muted.stretched-link.report-link
-                    | #{app.title} (paid app)
-              .small
-                b Version #{app.version}
-          br
+    form(method='POST')
+      #results
+        .container
+          for app in searchResults
+            .row.position-relative
+              .col-3.col-sm-2.col-md-2.my-auto
+                img.rounded(src=`${app.icon}` alt=`${app.appId} logo` width='50' height='50')
+              .col-9.col-sm-10.col-md-10.text-truncate.position-static
+                div
+                  if app.free && app.inDatabase
+                    a.stretched-link.report-link(href=`/analysis/${app.appId}`)
+                      | #{app.title}
+                  else if app.free
+                    button.btn.btn-link.p-0.text-left.stretched-link.report-link(
+                      type='submit'
+                      formaction=`/analysis/${app.appId}`)
+                      | #{app.title}
+                  else
+                    a.text-muted.stretched-link.report-link
+                      | #{app.title} (paid app)
+                .small
+                  b Version #{app.version}
+            br
+
+      if searchResults.some((app) => app.free && !app.inDatabase)
+        p.text-muted.small Select an app to confirm adding it to the analysis queue.
+        .cf-turnstile(
+          data-sitekey='0x4AAAAAAEM-nOb30hisDzEI'
+          data-action='request_analysis'
+          data-appearance='interaction-only')
 
 block app
   if app

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -31,17 +31,19 @@ html
             li.nav-item.mr-xl-3.ml-xl-3.mr-lg-2.ml-lg-2
               a.nav-link(href='/about') About
 
-          form.form-inline.my-2.my-lg-0(action="/search" method="POST")
-            input.form-control.mr-sm-2(
-              type='search'
-              placeholder='Search UK app'
-              name="search"
-              aria-label='Search UK app'
-              value=data.search)
-            .cf-turnstile(
-              data-sitekey='0x4AAAAAAEM-nOb30hisDzEI'
-              data-action='search_app'
-              data-appearance='interaction-only')
+        form.navbar-search-form.form-inline.my-2.my-lg-0(
+          action="/search"
+          method="POST")
+          input.form-control.mr-sm-2(
+            type='search'
+            placeholder='Search UK app'
+            name="search"
+            aria-label='Search UK app'
+            value=data.search)
+          .cf-turnstile(
+            data-sitekey='0x4AAAAAAEM-nOb30hisDzEI'
+            data-action='search_app'
+            data-appearance='interaction-only')
 
     if app === undefined
       .container.listing-reg

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -7,6 +7,7 @@ html
     link(rel='stylesheet', href='/css/bootstrap.min.css')
     link(rel='stylesheet', href='/css/exodus.css')
     link(rel='stylesheet', href='/css/styles.css')
+    script(src='https://challenges.cloudflare.com/turnstile/v0/api.js' async defer)
 
   body
     -data = data || {} // for search form
@@ -37,6 +38,10 @@ html
               name="search"
               aria-label='Search UK app'
               value=data.search)
+            .cf-turnstile(
+              data-sitekey='0x4AAAAAAEM-nOb30hisDzEI'
+              data-action='search_app'
+              data-appearance='interaction-only')
 
     if app === undefined
       .container.listing-reg

--- a/views/request-analysis.pug
+++ b/views/request-analysis.pug
@@ -1,0 +1,23 @@
+extends layout
+
+block content
+  h2 Request app analysis
+
+  if error
+    .alert.alert-warning(role='alert')= error
+
+  p
+    | This app has not been added to the analysis queue yet. Confirm the request below before TrackerControl contacts the App Store.
+
+  p
+    strong Bundle ID:
+    |  #{appId}
+
+  form(action=`/analysis/${appId}` method='POST')
+    .cf-turnstile.mb-3(
+      data-sitekey='0x4AAAAAAEM-nOb30hisDzEI'
+      data-action='request_analysis'
+      data-appearance='interaction-only')
+    button.btn.btn-primary(type='submit') Request analysis
+
+block app


### PR DESCRIPTION
## Summary

- render the existing Cloudflare Turnstile widget in the public app-search form
- validate tokens server-side through Siteverify before querying the App Store
- require distinct `search_app` and `request_analysis` actions and an explicitly allowed hostname
- keep `GET /analysis/:appId` database-only; unknown apps require a Turnstile-protected `POST`
- preserve rich Apple search results while making unknown free apps explicit queue requests
- cache Apple search metadata in a separate database table so selecting a result does not call Apple twice or enqueue every result
- extend Helmet CSP directives for the Turnstile script, frame, and verification traffic

## Impact

Automated clients can no longer submit public search or analysis requests without a valid, single-use Turnstile token. Unknown `GET /analysis/:appId` requests no longer contact Apple or mutate the database. Search metadata persists until a later search refreshes it, independently of the `apps` analysis queue.

Migration `011_app_store_cache.sql` only creates the additive `app_store_cache` table; it does not alter existing `apps` data.

Production requires `TURNSTILE_SECRET` and a comma-separated `TURNSTILE_HOSTNAMES` value. The public site key is intentionally embedded in the page.

## Validation

- `pnpm test` (48 tests passed)
- `git diff --check`
