### PR TITLE
Add accuracy disclaimers to the about and landing pages

### DIFF
--- a/views/about.pug
+++ b/views/about.pug
@@ -108,6 +108,13 @@ block content
   p
     | If a result looks wrong, tell us &mdash; corrections make this better for everyone.
 
+  h3.mt-5#disclaimer Use this information at your own risk
+  .alert.alert-warning(role='alert')
+    p
+      | The information on this site may be #[b out of date, incomplete or simply incorrect]. Apps change with every release, tracker databases lag behind the market, and automated analysis makes mistakes. Nothing here is verified by hand.
+    p.mb-0
+      | Everything is provided &ldquo;as is&rdquo;, without any warranty of accuracy, completeness or fitness for a particular purpose. #[b You use this information at your own risk.] Please check an individual result yourself before relying on it for anything that matters, and do not treat a report as a statement of fact about an app or the company behind it.
+
   h3.mt-5#background Where this comes from
   p
     | This project was motivated by #[a(target='_blank' rel='noopener noreferrer' href='https://exodus-privacy.eu.org/') Exodus Privacy], which is a similar project for Android apps. Some of the underlying code as well as the design of this website is based on this project.

--- a/views/form.pug
+++ b/views/form.pug
@@ -90,6 +90,11 @@ block content
     if searchResults.some((app) => app.free && !app.inDatabase)
       p.text-muted.small Apps that have not been analysed yet open a confirmation page first.
 
+  if !searchResults
+    .site-disclaimer.text-muted.small.mt-5.pt-4.border-top
+      p.mb-0
+        | #[b Please note:] the information shown here may be out of date, incomplete or incorrect. Reports describe the app version we analysed on the date shown, and automated analysis makes mistakes. Everything is provided without warranty &mdash; #[b use this information at your own risk]. Read the #[a(href='/about#disclaimer') full disclaimer].
+
 block app
   if app
     .container


### PR DESCRIPTION
Reports can lag behind the App Store, tracker databases are incomplete, and automated analysis mis-attributes things. This says so plainly in two places.

## Changes

- **`views/about.pug`** — new `#disclaimer` section, "Use this information at your own risk", placed after the existing limitations list. States that the information may be out of date, incomplete or incorrect, that everything is provided "as is" without warranty, and that individual results should be checked before being relied on.
- **`views/form.pug`** — a short footer note at the bottom of the landing page carrying the same warning and linking to `/about#disclaimer`. Guarded by `if !searchResults`, so it appears on `/` but not on search-result listings or app reports.

## Testing

- `npm test` — 119/119 pass.
- Rendered both templates directly to confirm the disclaimer appears on the homepage and about page, and is absent from the search-results render.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kg59fV86a11o2HP65CzkUg)_